### PR TITLE
Comment RE DARTEL warping in preprocessing

### DIFF
--- a/FirstLevel/Preprocess_mc_template.m
+++ b/FirstLevel/Preprocess_mc_template.m
@@ -163,6 +163,7 @@ HiresTemplate =    '[Exp]/Subjects/[Subject]/anatomy/HIRESSAG.nii';
 %%%      func = normalization of functional images to functional template
 %%%      anat = normalization of anatomical images to anatomical template
 %%%      seg  = normalization by segmentation of anatomical image
+%%%      note: seg will use VMB8 with DARTEL warping
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 normmethod = 'func';
 


### PR DESCRIPTION
This should be a straightforward pull request. Discussion in #20 among @mangstad and @heffjos indicated that the issue could be closed if a comment was added to the preprocessing template to indicate that the "seg" approach used VBM8 segmentation with DARTEL warping.

Can I get a +1 from @mangstad or @heffjos real quick to confirm that this makes everybody happy and closes #20?
