### PR TITLE
Spm8Batch/VersionLogging

### DIFF
--- a/spm8Batch/auxiliary/shellScriptFinalize
+++ b/spm8Batch/auxiliary/shellScriptFinalize
@@ -34,8 +34,10 @@ echo "#"                                                                        
 
 BATCHVERSION=`cat ${thisDir}/.spm8BatchVersion`
 [[ -f ${thisDir}/../.local/CurrentVersionSHA ]] && mcSHA=`cat ${thisDir}/../.local/CurrentVersionSHA`
+[[ -f ${thisDir}/../.local/mc_releasetag ]] && mc_releasetag=`cat ${thisDir}/../.local/mc_releasetag`
 
 echo "# spm8Batch Version : ${BATCHVERSION}"                                           >> ${FULLSCRIPTNAME}.sh
+echo "# MethodsCore Release Tag : ${mc_releasetag}"                                    >> ${FULLSCRIPTNAME}.sh
 echo "# MethodsCore Repository SHA-ID: $mcSHA"                                         >> ${FULLSCRIPTNAME}.sh
 echo "#"                                                                               >> ${FULLSCRIPTNAME}.sh
 echo "# All done"                                                                      >> ${FULLSCRIPTNAME}.sh


### PR DESCRIPTION
Enhance version logging in spm8Batch. Previously, only .spm8BatchVersion file in spm8Batch subdirectory was `cat` to log, but now, both CurrentVersionSHA and mc_releasetag from .local of mcRoot will be included, as further elaborated here https://github.com/UMPsychMethodsCore/MethodsCore/wiki/Release-Tracking
