### PR TITLE
Bug in mc_Logger

### DIFF
--- a/matlabScripts/mc_Logger.m
+++ b/matlabScripts/mc_Logger.m
@@ -108,6 +108,7 @@ function result = mc_Logger(cmd,argument,loglevel)
                 mc_Error('Could not open logfile %s for writing.',mcLog);
             end
             fprintf(fid,'%s\t%s\n',loglevelstr,cmdstring);
+            fclose(fid);
             result = 1;
     end
     


### PR DESCRIPTION
Noticed today I forgot to fclose the logfile after writing log messages.  This can cause matlab scripts to fail if there are too many open files.
