### PR TITLE
svmbatch | Fix contrastAvail

### DIFF
--- a/svmbatch/matlab_Scripts/connectome_class_driver_mc_central.m
+++ b/svmbatch/matlab_Scripts/connectome_class_driver_mc_central.m
@@ -285,7 +285,7 @@ if strcmpi(svmtype,'paired')
 
     %% Figure out subject availability for contrasts
 
-    contrastAvail = zeros(nSubs,size(ContrastVec));
+    contrastAvail = zeros(nSubs,size(ContrastVec,1));
 
     for iContrast = 1:size(ContrastVec,1);
         curContrast=ContrastVec(iContrast,:);


### PR DESCRIPTION
contrastAvail will now be properly initialized to be nSubs \* nContrasts, which will it get from the number of rows of ContrastVec.

This addresses #122
