### PR TITLE
added ability to specify an ROI directory instead of a list of files

### DIFF
--- a/som/som_batch_mc_central.m
+++ b/som/som_batch_mc_central.m
@@ -140,7 +140,9 @@ if (RunMode(1) | sum(RunMode) == 0)
                     ROI{iROIs} = fullfile(ROIFolder,ROIImages{iROIs});
                 end
                 parameters.rois.files = char(ROI);
-            
+            case 'directory'
+                ROIFolder = mc_GenPath(ROITemplate);
+                parameters.rois.files = spm_select('FPList',ROIFolder,'.*\.img|.*\.nii');
             case 'coordinates'
                 parameters.rois.mni.coordinates = ROICenters;
                 if (iscell(ROISize))
@@ -170,7 +172,7 @@ if (RunMode(1) | sum(RunMode) == 0)
         end
 
         parameters.Output.correlation = ROIOutput;
-	parameters.Output.saveroiTC = saveroiTC;
+        parameters.Output.saveroiTC = saveroiTC;
         %parameters.Output.description = 'description of output';
         parameters.Output.directory = OutputPath;
         parameters.Output.name = OutputName;

--- a/som/som_batch_mc_template.m
+++ b/som/som_batch_mc_template.m
@@ -239,10 +239,13 @@ Fraction = 1;
 %%% Type of input
 %%%         coordinates - provide the center of each seed and a radius
 %%%         files       - provide a list of ROI files
+%%%         directory   - provide a directory containing ROI files and the
+%%%                       script will load all images in that directory to 
+%%%                       use as ROIs
 %%%         grid        - make a grid based on provided spacing and masked
 %%%                       by provided mask
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-ROIInput = 'coordinates';
+ROIInput = 'directory';
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% If specifying ROI coordinates you need to provide a list of centers in 
@@ -270,7 +273,9 @@ ROISize = {19};
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% If specifying ROI images you need to provide an ROI folder as well as a
-%%% cell array list of ROI images.
+%%% cell array list of ROI images.  If specifying an ROI directory, you only
+%%% need to specify an ROITemplate.  The script will then load all images
+%%% in that directory to use as the ROIImages cell array.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 ROITemplate = '[Exp]/ROIS';
 ROIImages = {


### PR DESCRIPTION
@takwatanabe2004 @sripada I'll merge this into som_alpha.  You should now be able to give it a directory and it will pull all image files from that directory as ROIs.  I didn't really test it but the logic should work so let me know right away if it seems to fail.
