### PR TITLE
Add support for paired t-test based pruning

### DIFF
--- a/svmbatch/matlab_Scripts/connectome_class_driver_mc_central.m
+++ b/svmbatch/matlab_Scripts/connectome_class_driver_mc_central.m
@@ -369,7 +369,13 @@ if strcmpi(svmtype,'paired')
                 % signed direction. Do it just for one pair, since the second pair
                 % is the first * -1
 
-                featurefitness=max(  [sum(train(1:2:end,:)>0,1)/size(train(1:2:end,:),1) ;sum(train(1:2:end,:)<0,1)/size(train(1:2:end,:),1)]  );
+                allowedpruneMethod={'t-test','fractfit'};
+                
+                if ~any(strcmp(pruneMethod,allowedpruneMethod))
+                    pruneMethod='fractfit'; % if not properly set, use fractfit
+                end
+                    
+                featurefitness=mc_calc_discrim_power_paired(train,trainlabels,pruneMethod);
 
                 LOOCV_featurefitness{iContrast}(iL,:) = featurefitness;
 

--- a/svmbatch/matlab_Scripts/connectome_class_driver_mc_template.m
+++ b/svmbatch/matlab_Scripts/connectome_class_driver_mc_template.m
@@ -20,8 +20,12 @@ svmtype='paired';
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Pruning Method. For non-paired SVM, how would you like the select the
 %%% most discriminant features. Presently supported options are...
-%%%     'ttest'     -   two-sample t-test
-%%%     'taub'      -   Kendall's tau-b coefficient of correlation with labels
+%%%     unpaired data
+%%%         'ttest'     -   two-sample t-test
+%%%         'taub'      -   Kendall's tau-b coefficient of correlation with labels
+%%%     paired data
+%%%         't-test'    -   paired t-test
+%%%         'fractfit'  -   fractional fitness
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 pruneMethod = 'ttest';


### PR DESCRIPTION
Added support in central script for parsing of pruneMethod (and setting to default in case of legacy scripts) only in paired cases

Added usage of mc_calc_discrimpower_paired in place of manual discrim power calculation in paired cases. Net effect of this commit is addition of paired t-test support, though it was achieved in a more comprehensive way
