### PR TITLE
fix for crash when running sequentially in the same matlab session.

### DIFF
--- a/FirstLevel/FirstLevel_mc_central.m
+++ b/FirstLevel/FirstLevel_mc_central.m
@@ -416,7 +416,7 @@ for iSubject = 1:NumSubject %First level fixed effect, subject by subject
     end
     SandboxOutputDir = mc_GenPath(fullfile(Sandbox,OutputTemplate));
     display(sprintf('\n\nI am going to save the output here: %s', OutputDir));
-
+    curpath = pwd;
     if (Mode == 1 | Mode ==2) 
         if (strcmp(OutputDir(end),filesep))
             OutputDir = OutputDir(1:end-1);
@@ -865,7 +865,7 @@ for iSubject = 1:NumSubject %First level fixed effect, subject by subject
         mc_FixSPM(OutputDir,Sandbox,'');
         
     end
-    
+    cd(curpath);
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     %%%%%%%%%%    Done with subject   %%%%%%%%%%%%%%%%
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
crash was due to sandbox folder being removed, but the script didn't cd out of it first.

This crash will still happen in the somewhat unlikely scenario where a user kills the script (via ctrl-c) or it crashes, then they delete the sandbox folder, then run again in the same matlab session.  I'll look into that, but it's a low priority, and I'm not sure it's really possible to catch that short of putting the whole central script in a try/catch block.
