### PR TITLE
added ability to specify SPM default values in First Level template

### DIFF
--- a/FirstLevel/FirstLevel_mc_central.m
+++ b/FirstLevel/FirstLevel_mc_central.m
@@ -44,6 +44,9 @@ spmver = spm('Ver');
 if (strcmp(spmver,'SPM8')==1)
 	spm_jobman('initcfg');
 	spm_get_defaults('cmdline',true);
+    if (exist('spmdefaults','var'))
+        mc_SetSPMDefaults(spmdefaults);
+    end
 end
 
 RunNamesTotal = RunDir;

--- a/FirstLevel/FirstLevel_mc_template.m
+++ b/FirstLevel/FirstLevel_mc_template.m
@@ -375,6 +375,28 @@ StartOp=1;
 ContrastRunWeights = {
     };
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% SPM Default Values for First Level analysis
+%%% this is set up as a cell array where each row corresponds to a default
+%%% value in SPM.  The first element is a string with the name of the
+%%% default field (without defaults. at the beginning).  You can view
+%%% spm_defaults.m for a list of possible fields to set.  The second
+%%% element is the value you want to set for that default.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% The main default that impacts first level analysis is the implicit 
+%%% masking threshold. The default is 0.8 which means that voxels that have
+%%% a value of less than 80% of the grand mean will be masked out of the
+%%% analysis.  This default value can be problematic in some susceptibility
+%%% prone areas like OFC.  A more liberal value like 0.5 can help to keep
+%%% these regions in the analysis.  If you set this value very low, you'll
+%%% want to use an explicit mask to exclude non-brain regions from
+%%% analysis.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+spmdefaults = {
+    'mask.thresh'   0.8;
+};
 
 
 global mcRoot;

--- a/matlabScripts/mc_SetSPMDefaults.m
+++ b/matlabScripts/mc_SetSPMDefaults.m
@@ -1,0 +1,28 @@
+function mc_SetSPMDefaults(spmdefaults)
+% A utility function to set SPM8 default values
+% FORMAT mc_SetSPMDefaults(spmdefaults);
+%
+% spmdefaults        A cell array containing SPM default fields to set.
+%                    For example: 
+%                        spmdefaults = {
+%                           'mask.thresh'  0.5;
+%                           'stats.fmri.ufp'  0.05;
+%                        };
+%
+
+global defaults;
+
+if (isempty(spmdefaults))
+    return;
+end
+
+if (~iscell(spmdefaults))
+    mc_Error('mc_SetSPMDefaults requires a cell array but was passed something else.  Check your spmdefaults variable.');
+    return;
+end
+
+for iDefault = 1:size(spmdefaults,1)
+    spm_get_defaults(spmdefaults{iDefault,1},spmdefaults{iDefault,2});
+end
+
+


### PR DESCRIPTION
This includes an spmdefaults variable in the template script advanced section, a new utility function in matlabScripts that takes that variable and calls spm_get_default to set the values, and a change in the central script to call this utility function.

This should address issue #105
