### PR TITLE
Fix for bug in FirstLevel script

### DIFF
--- a/FirstLevel/FirstLevel_mc_central.m
+++ b/FirstLevel/FirstLevel_mc_central.m
@@ -411,7 +411,7 @@ for iSubject = 1:NumSubject %First level fixed effect, subject by subject
 
 
     OutputDir = mc_GenPath(OutputTemplate);
-    if (exist(OutputDir,'dir') && mode == 1) %if outputdir already exists, remove it for new results
+    if (exist(OutputDir,'dir') && Mode == 1) %if outputdir already exists, remove it for new results
         result = rmdir(OutputDir,'s');
         if (result == 0)
             mc_Error('Output directory %s\nalready exists and cannot be removed. Please check you permissions.',OutputDir);


### PR DESCRIPTION
Currently if the FirstLevel script is run in mode = 2 (contrast add-on mode) it fails because there was a line in the script that removes the results folder if it exists (to avoid SPM warnings about existing results which stall processing).

Unfortunately, this was still being done in contrast add-on mode which is obviously incorrect behavior.  The fix is just to only remove the directory if we're running in mode=1 (normal operation) and not in contrast add-on or test mode.

We'll want to push this as a hotfix I assume, so can I get a code review and +1 from @dankessler , @sripada , and/or @heffjos 
