### PR TITLE
fix for explicitmask not working

### DIFF
--- a/FirstLevel/FirstLevel_mc_central.m
+++ b/FirstLevel/FirstLevel_mc_central.m
@@ -649,9 +649,7 @@ for iSubject = 1:NumSubject %First level fixed effect, subject by subject
 
 
     SPM.xM.VM = [];
-    if (~isempty(explicitmask))
-        SPM.xM.VM = spm_vol(explicitmask);
-    end
+
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     %%%%%%%%%% Configure design matrix %%%%%%%%%%%%%%
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -659,6 +657,11 @@ for iSubject = 1:NumSubject %First level fixed effect, subject by subject
         SPM = spm_fmri_spm_ui(SPM);
     end
 
+    if (exist('explicitmask','var') && ~isempty(explicitmask))
+        SPM.xM.VM = spm_vol(explicitmask);
+        SPM.xM.xs.Masking = [SPM.xM.xs.Masking '+explicit mask'];
+    end
+    
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     %%%%%%%%%% Estimation %%%%%%%%%%%%%%%%%%%%%%%%%%%
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Just moved the spm_vol command to load the explicit mask to after spm_fmri_spm_ui call.

Tested and it successfully used an explicit mask.
