### PR TITLE
Small bug in the moveToSandbox that became broken when introducing abili...

### DIFF
--- a/spm8Batch/matlabScripts/moveToSandBox.m
+++ b/spm8Batch/matlabScripts/moveToSandBox.m
@@ -38,7 +38,7 @@ if exist(SandBoxPID) == 7
     CS=0
     SandBoxPID='';
   else    
-    FILESTOMOVE=dir([sourceDir '/' sourceVolume sourceExtension]);
+    FILESTOMOVE=dir([sourceDir '/' sourceVolume sourceExtension(2:end)]);
     %
     % Big assumption is one nifti file per directory
     %


### PR DESCRIPTION
Small bug in the moveToSandBox.m that became broken when introducing ability to handle img/hdr as well. With the introduction of a volume extension spm_select likes '._.nii' while built in matlab dir command wants '_.nii'

I modified this line 

```
 FILESTOMOVE=dir([sourceDir '/' sourceVolume sourceExtension]);
```

to be

```
 FILESTOMOVE=dir([sourceDir '/' sourceVolume sourceExtension(2:end)]);
```
