### PR TITLE
mc_CsvRead

### DIFF
--- a/matlabScripts/mc_CsvRead.m
+++ b/matlabScripts/mc_CsvRead.m
@@ -34,9 +34,10 @@ function M = mc_CsvRead(fileName, delimiter)
     end
 
     M = [];
-    line = strtrim(fgetl(fid));
+    line = fgetl(fid);
     lineNum = 1;
-    while ischar(line)
+    while ischar(line) == 1
+        line = strtrim(line);
         if length(line) > 0 && line(1) ~= '#'
             tmpRow = parseLine(line, delimiter);
             if isempty(tmpRow)


### PR DESCRIPTION
@mangstad mc_CsvRead was updated to parse tab/spac/comma separated variables.  mc_CsvRead assumes the numerical values are delimited by white space.  It assumes the numerical values are delimited by ',' if and only if no delimiter argument is passed.  Let me know if this is what you had in mind.
