### PR TITLE
Hotfix for SecondLevel bug

### DIFF
--- a/SecondLevel/SecondLevel_mc_central.m
+++ b/SecondLevel/SecondLevel_mc_central.m
@@ -1167,9 +1167,12 @@ function [des con des2] = fblock(model,columns)
     
 function images = get_images(p,i)
     global options;
+    if (numel(i)==1)
+        i = repmat(i,size(p,1),1);
+    end
     for n=1:size(p,1)
         subject = strtrim( p(n,:) );
-        imageName = strcat(options.other.ContrastPrefix,'_',sprintf('%04d',i(1)),options.other.InputImgExt);
+        imageName = strcat(options.other.ContrastPrefix,'_',sprintf('%04d',i(n)),options.other.InputImgExt);
         imageCheck.Template = fullfile(options.other.MainDir,subject,options.other.ModelDir,imageName);
         imageCheck.mode = 'check';
         %image = mc_GenPath(imageCheck);


### PR DESCRIPTION
There was a bug in the secondlevel that was encountered when using ImCol=0 (so ImCol in a jobfile refers to a scanfile column rather than a direct contrast number) and when subjects have differing contrast numbers.  This is an extremely rare case, but it was functioning incorrectly since it was always grabbing i(1) before so all subjects were using the contrast number from the first subject.

The fix is to use i(n) so each subject gets their own contrast image correctly.  However, this would break ImCol=1 mode (the preferred usage at this point) because in that case i is only a scalar.  So a quick check is introduced to check whether i is scalar, and if so to replicate it to the number of subjects (rows of p).  Then i(n) is used in the loop so each subject is correctly assigned their own contrast image number in the rare case.

If I can get a +1 I'll go ahead and merge to public and update again.
