### PR TITLE
PPI condition name bug Edit

### DIFF
--- a/FirstLevel/FirstLevel_mc_central.m
+++ b/FirstLevel/FirstLevel_mc_central.m
@@ -895,6 +895,8 @@ for iSubject = 1:NumSubject %First level fixed effect, subject by subject
                 if (clrs < CalcNumRegRun(iRun))
                     numz = CalcNumRegRun(iRun) - clrs;
                     tempContrast = [ContrastList{iContrast,NumCond+2} zeros(1,numz)];
+                else
+                    tempContrast = [ContrastList{iContrast,NumCond+2}];
                 end
                 ContrastBase = horzcat(ContrastBase,tempContrast);
             end

--- a/PPI/PPI_mc_central.m
+++ b/PPI/PPI_mc_central.m
@@ -127,16 +127,24 @@ for iSubject = 1:size(SubjDir,1)
             CondPresent = zeros(1,TotalNumCond);
             for iCond = 1:NumCond
                 for iCondTotal = 1:TotalNumCond
-                    match = strfind(SPM.Sess(iRun).U(iCond).name{1},ConditionName{iCondTotal}); %need to adjust for parametric PPI
-                    if (~isempty(match))
-                        %weights(iCond) = fullweights(iCondTotal);
-                        if (fullweights(iCondTotal)~=0)
-                            CondPresent(iCondTotal) = iCond;
-                        else
-                            CondPresent(iCondTotal) = -iCond;
-                        end
-                        weights(iCond,:) = [iCond 1 fullweights(iCondTotal)];
+                    temp = strfind(SPM.Sess(iRun).U(iCond).name{1},ConditionName{iCondTotal}); %need to adjust for parametric PPI
+                    if (~isempty(temp))
+                        match(iCondTotal) = size(ConditionName{iCondTotal},2);
+                    else
+                        match(iCondTotal) = 0;
                     end
+                end
+                [maxmatch, idxmatch] = max(match);
+                
+                if (idxmatch>0)
+                    iCondTotal = idxmatch;
+                    %weights(iCond) = fullweights(iCondTotal);
+                    if (fullweights(iCondTotal)~=0)
+                        CondPresent(iCondTotal) = iCond;
+                    else
+                        CondPresent(iCondTotal) = -iCond;
+                    end
+                    weights(iCond,:) = [iCond 1 fullweights(iCondTotal)];
                 end
             end
             

--- a/PPI/PPI_mc_template.m
+++ b/PPI/PPI_mc_template.m
@@ -103,7 +103,7 @@ PPIType = 'standard';
 %%% contain only 0s and 1s and determines which conditions to include.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 ROIs = {
-	'vmPFC',[8 42 -12],[5],[1 1 0];
+	'vmPFC',[8 42 -12],[5],[1 -1 0];
 };
 
 


### PR DESCRIPTION
This introduces a fix for a bug that was just discovered. If a subsequent condition name was a subset of an earlier condition, it obviously matched both, and the incorrect subsequent condition was taken to be the match.

In the fix, all conditions are first checked for a name match, and matching conditions have their condition name length added to an array. After all conditions have been checked, the longest winning condition is taken to be the winner.

@dankessler could you take a look at the bugfix on this and let me know if you see any remaining issues.
