### PR TITLE
FirstLevel corrected log message

### DIFF
--- a/FirstLevel/FirstLevel_mc_central.m
+++ b/FirstLevel/FirstLevel_mc_central.m
@@ -602,7 +602,7 @@ for iSubject = 1:NumSubject %First level fixed effect, subject by subject
                             NonZeroRegColumns = NonZeroRegColumns - 1;
                         end
                     end
-                    mc_Logger('log',sprintf('Found %d non-constant regressors in file %s.  Using %d of them.',NonZeroRegColumns,File,min(NonZeroRegColumns,RegColumns)));
+                    mc_Logger('log',sprintf('Found %d non-constant regressors in file %s.  Using %d of them.',NonZeroRegColumns,File,min(NonZeroRegColumns,RegColumns)),3);
                     fprintf(1,'Found %d non-constant regressors in file %s.  Using %d of them.\n',NonZeroRegColumns,File,min(NonZeroRegColumns,RegColumns));
                 end
             end


### PR DESCRIPTION
Message for number of regressors found was incorrectly being recorded as an error message.  Corrected the call to indicate a status message now.
