### PR TITLE
fix multi regression contrast bug

### DIFF
--- a/SecondLevel/SecondLevel_mc_central.m
+++ b/SecondLevel/SecondLevel_mc_central.m
@@ -156,11 +156,11 @@ function [jobs jobs2] = SecondLevel_mc_central(opt)
 		  cn = 1;
 		  for r = 1:length(options.models(N).reg)
 		      con.consess{cn}.tcon.name = [options.models(N).reg(r).name ' pos'];
-		      con.consess{cn}.tcon.convec = [zeros(1,(r-1)) 1];
+              con.consess{cn}.tcon.convec = [zeros(1, r) 1];
 		      con.consess{cn}.tcon.sessrep = 'none';
 		      cn = cn + 1;
 		      con.consess{cn}.tcon.name = [options.models(N).reg(r).name ' neg'];
-		      con.consess{cn}.tcon.convec = [zeros(1,(r-1)) -1];
+              con.consess{cn}.tcon.convec = [zeros(1, r) -1];
 		      con.consess{cn}.tcon.sessrep = 'none';
 		      cn = cn + 1;
 		  end


### PR DESCRIPTION
In a multiple regression design, the constant column is the first column.  The contrast vectors will now be created appropriately.
