### PR TITLE
Corrected typon ExtractROI_mc_central.m.  Wrong variable name was used f...

### DIFF
--- a/ROIScripts/ExtractROI_mc_central.m
+++ b/ROIScripts/ExtractROI_mc_central.m
@@ -189,7 +189,7 @@ for ijob = 1 : size(ExtractionJobs,1)
     SPMPrevious.SPM.xY.P=SPMData.SPM.xY.P;
 
     % now log the usage
-    str = sprintf('spm_file:%s ROIScripts complete\n', spm_file);
+    str = sprintf('spm_file:%s ROIScripts complete\n', spm_name);
     UsageResult = mc_Usage(str, 'ROIScripts');
     if ~UsageResult
         mc_Logger('log', 'Unable to wrtie some usage information');


### PR DESCRIPTION
...or spm file.
