### PR TITLE
fix for sed differences between mac/linux

### DIFF
--- a/.deploy/src/checkout.sh
+++ b/.deploy/src/checkout.sh
@@ -29,7 +29,7 @@ if [ -f .local/deployment ]; then #Only run this if in a deployment
 
     for file in $templatelist
     do
-	sed -i -e '/%DEVSTART/,/%DEVSTOP/ d' \
+	sed -i'' -e '/%DEVSTART/,/%DEVSTOP/ d' \
 	    -e "s:%\[DEVmcRootAssign\]:mcRoot = \'$mcRoot\':" \
 	    -e "s:%\[DEVmcRoot\]:$mcRoot:"  \
 	    $file


### PR DESCRIPTION
This just adds an empty set of quotes after the -i flag for sed. The string here is for a backup file extension for the inplace sed command. It is optional on Linux, but mandatory on Mac. Providing an empty string is the same as the default behavior on Linux (i.e. no backup file).
