### PR TITLE
Final fix for Mac/Linux sed differences

### DIFF
--- a/.deploy/src/checkout.sh
+++ b/.deploy/src/checkout.sh
@@ -29,9 +29,6 @@ if [ -f .local/deployment ]; then #Only run this if in a deployment
 
     for file in $templatelist
     do
-	sed -i'' -e '/%DEVSTART/,/%DEVSTOP/ d' \
-	    -e "s:%\[DEVmcRootAssign\]:mcRoot = \'$mcRoot\':" \
-	    -e "s:%\[DEVmcRoot\]:$mcRoot:"  \
-	    $file
+	sed -i'' -e "/%DEVSTART/,/%DEVSTOP/ d; s:%\[DEVmcRootAssign\]:mcRoot = \'$mcRoot\':; s:%\[DEVmcRoot\]:$mcRoot:" $file
     done
 fi


### PR DESCRIPTION
Okay, the last fix was only half the issue. Mac sed apparently also doesn't accept multiple -e command flags. However, just joining multiple sed commands in a single -e flag with semicolon delimiter seems to be supported by both Mac and Linux.
