### PR TITLE
Changes to Conn to allow saving of 4D preprocessed data, and small bu…

### DIFF
--- a/ConnTool/Code/SOM_CalculateCorrelationMaps.m
+++ b/ConnTool/Code/SOM_CalculateCorrelationMaps.m
@@ -55,6 +55,10 @@ SOM_LOG('STATUS : Entering CorrCoeff Map Calculation');
 rMatrix  = zeros(parameters.rois.nroisRequested,parameters.rois.nroisRequested);
 pMatrix  =  ones(parameters.rois.nroisRequested,parameters.rois.nroisRequested);
 
+% Added RCWelsh - 2016-11-21 - to calculated the zmatrix as well.
+
+zMatrix  = rMatrix;
+
 % Array of ROI time courses.
 
 roiTC = zeros(size(D0,2),parameters.rois.nroisRequested);
@@ -92,15 +96,19 @@ else
   nameOption = '_paritalcorr';
 end
 
+zMatrix = SOM_Rho2Z(rMatrix);
+
 % It is quite possible that some of the ROI's are messed up? That
 % is they don't really exist, even though specified. We can easily 
-% known those out.
+% zero those out.
 
 for iROI = 1 : parameters.rois.nroisRequested
   if parameters.rois.ROIOK(iROI) == 0
     rMatrix(iROI,:) = 0;
+    zMatrix(iROI,:) = 0;
     pMatrix(iROI,:) = 1;
     rMatrix(:,iROI) = 0;
+    zMatrix(:,iROI) = 0;
     pMatrix(:,iROI) = 1;
     if parameters.Output.saveroiTC ~= 0
       roiTC(:,iROI) = 0; % also zero out the time course if the rMat is censored
@@ -126,12 +134,12 @@ corrName = fullfile(parameters.Output.directory,[parameters.Output.name nameOpti
 
 %
 % Now recalculate the p-values based on fewer degrees of freedom.
-%
+% -- not doing that yet, but need to. - RCWelsh 2016-11-21
 
 if parameters.Output.power
-  save(corrName,'rMatrix','pMatrix','power');
+  save(corrName,'rMatrix','pMatrix','zMatrix','power');
 else
-  save(corrName,'rMatrix','pMatrix');
+  save(corrName,'rMatrix','pMatrix','zMatrix');
 end
 
 results = corrName;

--- a/ConnTool/Code/SOM_CheckDataStructure.m
+++ b/ConnTool/Code/SOM_CheckDataStructure.m
@@ -70,14 +70,14 @@ for iRUN = 1:length(data.run)
         return
     end
     
-    if isfield(data.run(iRUN),'cP') == 0
-        SOM_LOG(sprintf('WARNING : Missing cP variable in parameters.data, will use P for run %d',iRUN));
-        data.run(iRUN).cP = P;
-    end
-    
     if ischar(data.run(iRUN).P) == 0
         SOM_LOG('FATAL ERROR : You need to specify a character array of files');
         return
+    end
+    
+    if isfield(data.run(iRUN),'cP') == 0
+        SOM_LOG(sprintf('WARNING : Missing cP variable in parameters.data, will use P for run %d',iRUN));
+        data.run(iRUN).cP = data.run(iRUN).P;  % Fixed RCWelsh 2016-11-21
     end
     
     if ischar(data.run(iRUN).cP) == 0

--- a/ConnTool/Code/SOM_WriteNII.m
+++ b/ConnTool/Code/SOM_WriteNII.m
@@ -53,25 +53,26 @@ if length(niiDIM) < length(volDIM)
     niiDIM = [niiDIM 1];
 end
 
-if any(volDIM(1:3)-niiDIM)
+if any(volDIM(1:3)-niiDIM(1:3))
   SOM_LOG(sprintf('FATAL ERROR : TemplateImage dimension doesn''t match data dimension to be written\n'));
   return 
 end
 
 % data area.
-niftiOutData          = file_array;
-
-niftiOutData.fname    = NewName;
-niftiOutData.dim      = volDIM;
 
 % No error checking on that they pass in!!!
 if exist('dtype') == 0
-  niftiOutData.dtype    = niftiIn.dat.dtype;
-else
-  niftiOutData.dtype     = dtype;
+  dtype    = niftiIn.dat.dtype;
 end
 
-niftiOutData.offset   = niftiIn.dat.offset;
+% Fixed on 2016-11-18 - RCWelsh to fully call with all parameters
+
+% Seems best to force the offset to be 0 instead of the offset from the
+% template image. When I try to use niftiIn.dat.offset, the results are 
+% a badly shifted image. Most likely the offset is forced to be 0 by SPM 
+% even though it's specified otherwise.
+
+niftiOutData          = file_array(NewName,volDIM,dtype,0,niftiIn.dat.scl_slope,niftiIn.dat.scl_inter,'rw');
 
 % header area
 niftiOut              = nifti;

--- a/ConnTool/ConnTool_batch_mc_template.m
+++ b/ConnTool/ConnTool_batch_mc_template.m
@@ -123,6 +123,7 @@ NumScan = [9999 9999];
 %%%                       but do not run any ConnTool code
 %%%    'presave'    = run ConnTool code on previously saved parameters
 %%%    'full'       = generate parameters and immediately run ConnTool code
+%%%    'preprocsave'= preprocess the data, and then save the D0 to a 4D file.
 %%%
 %%%    NOTE: If you choose mode 'presave' then most variables except
 %%%       SubjDir and OutputTemplate/OutputName will be ignored as they
@@ -571,7 +572,7 @@ addpath(fullfile(mcRoot,'matlabScripts'));
 addpath(fullfile(mcRoot,'ConnTool'));
 addpath(fullfile(mcRoot,'ConnTool/Code'));
 addpath(fullfile(mcRoot,'ConnTool/matlab'),'-END');
-addpath(fullfile(mcRoot,'SPM','SPM8','spm8_with_R4667'));
+addpath(fullfile(mcRoot,'SPM','SPM8','spm8_with_R6313'));
 
 ConnToolCallingScriptName = which(mfilename);
 


### PR DESCRIPTION
@dankessler @dankessler @sripada 

Allowing the code to preprocess the data, but not run correlations and allows the 4D data to be saved for later preprocessing. This can be a time saver for looking at the same preprocessed 4D data and using different ROI schemes or bandpass filtering etc.

Changes are:

SOM_WriteNII.m
    changed how file_array is called, directly pass parameters
    default to using vox_offset of 0.

ConnTool_batch_mc_central.m
    put in logic to handle processing flag ‘preprocsave’, removed ‘som’ switch as it’s not documented.
    instead of using “diff”, use “gradient” to calculate the derivatives.

ConnTool_batch_mc_template.m
    introduced ‘preprocsave’ as processing switch to preprocess and then save the 4D nifti file to the Output area.

Code/SOM_CheckDataStructure.m
    fixed bug that if confound times-series file was not specified it would not correctly default to using the signal time-series file, this threw an error. now set cP to be data.run.P properly and change order of checking so that P is checked fully and then cP is checked. 

SOM_CalculateCorrelationMaps.m
    automatically calculate the z values from r with SOM_Rho2Z

I've tested locally on my mac with a single subject and passed the test. I'll need a +1 and somebody to merge into dev.