### PR TITLE
ConnTool template bug fix

### DIFF
--- a/ConnTool/ConnTool_batch_mc_central.m
+++ b/ConnTool/ConnTool_batch_mc_central.m
@@ -484,6 +484,7 @@ if (RunMode(1) | sum(RunMode) == 0)
                 switch(ROIInput)
                     case 'coordinates'
                         grid_coord = ROICenters;
+                        ROIGridSize = ROISize;
                     case 'coordload'
                         [ROIFileName EC] = mc_GenPath(ROIFile);
                         if ~isempty(EC)
@@ -534,7 +535,7 @@ if (RunMode(1) | sum(RunMode) == 0)
                     XYZ = SOM_MakeSphereROI(ROIGridSize);
                     parameters.rois.mni.size.XROI = XYZ(1,:);
                     parameters.rois.mni.size.YROI = XYZ(2,:);
-                    parameters.rois.mni.size.ZROI = XYZ(2,:);
+                    parameters.rois.mni.size.ZROI = XYZ(3,:);
                 end
         end
         


### PR DESCRIPTION
This is to address the two bugs recently identified and announced to the MethodsCoreUsers list. One was due to a typo grabbing the 2nd rather than 3rd row of a matrix, and the other was due to an oversight where ROISize was not being used for coordinates mode, instead it was falling back to ROIGridSize.